### PR TITLE
Specify UTC time zone in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ An example of calling nwb_file.open is given below;
 	settings["file_name"] = "filename.nwb"
 	settings["identifier"] = utils.create_identifier("some string; will be added to unique identifier")
 	settings["mode"] = "w"
-	settings["start_time"] = "2016-04-07T03:16:03.604121"
+	settings["start_time"] = "2016-04-07T03:16:03.604121Z"
 	settings["description"] = "Description of the file"
 
 	# specify an extension (Could be more than one).


### PR DESCRIPTION
ISO:8601 allows to specify the timezone to unambiguously mark it as UTC via
appending a "Z". See e.g. 5.3.3 in
http://www.cs.utsa.edu/~wagner/date/8601.pdf.

Use that here to give future users a nice example.

The default timezone for the python module iso8601 is UTC, so this is
ambiguity only exists for other programming languages.
