### PR TITLE
Improve installation process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/NeurodataWithoutBorders/api-python nwb_api-python
 
 (The last parameter is optional.  Providing it, will cause the software to be stored in a directory named "nwb_api-python" rather than 'api-python').
 
-After you get the latest software, to install it using:
+After you get the latest software, install it using:
 
 ```
 python setup.py install
@@ -32,6 +32,34 @@ git pull origin
 then re-run ```python setup.py install``` to install the updates.
 
 Try running the examples in directory examples/create_scripts directory and also the unit tests in the unittest directory.
+
+### Installing using conda
+
+The NWB API depends on HDF5 (accessed via the h5py library) and with the
+default install will use whatever version is installed on your system.
+You can install it within a [conda] environment to keep it isolated from
+other software, for instance if you wish to use a different version of HDF5,
+or not have h5py installed globally.
+
+Once you have [installed conda], you can use the following commands to set
+up an environment for NWB:
+
+```
+conda create -n nwb python=2.7 h5py
+# Activate the conda environment with one of the following two lines
+source activate nwb # Linux, Mac OS
+activate nwb        # Windows
+# Build & install the API within the environment
+cd nwb_api-python
+pip install -e .
+```
+
+With this approach (in particular the `-e` flag) updates to the API obtained
+with `git pull` will automatically be reflected in the version installed in
+the environment.
+
+[conda]: http://conda.pydata.org/docs/get-started.html
+[installed conda]: http://conda.pydata.org/docs/install/quick.html
 
 ## 3. Using the API.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The Python API for the NWB format is a write API that can be used to create NWB 
 
 ## 2. Installaton.
 
+Note: at present this requires Python 2, but Python 3 support is being worked on and should be ready soon.
+
 ```
 git clone https://github.com/NeurodataWithoutBorders/api-python nwb_api-python
 ```

--- a/matlab_bridge/0_INSTALL.txt
+++ b/matlab_bridge/0_INSTALL.txt
@@ -60,7 +60,7 @@ location of the Python interpreter   is:
     executable: '/Users/jt/anaconda/bin/python'
        library: '/Users/jt/anaconda/lib/libpython2.7.dylib'
           home: '/Users/jt/anaconda'
-      isloaded: 1
+      isloaded: 0
 
    If the location of the executable displayed by "pyversion" matches the location
    you found in step 2, then matlab is already setup to use the correct Python
@@ -77,7 +77,16 @@ location of the Python interpreter   is:
 4. Add the 'matlab_bridge_api' directory to your matlab path.  Do this by
    clicking on the "Set Path" icon in MatLab, and navigating to directory
    "matlab_bridge/matlab_bridge_api", and add that directory to your matlab
-   search path. 
+   search path.
+
+5. Tell Matlab not to abort if the Python API uses a different HDF5 version.
+   Matlab has its own copy of the HDF5 library internally, but the NWB
+   Python API will be using your system's HDF5 library (or one in a conda
+   environment, depending on how you built the API). If these are different
+   versions, by default HDF5 will make Matlab abort. You can disable this
+   check with the Matlab command `setenv('HDF5_DISABLE_VERSION_CHECK', '1')`
+   before using any NWB features. Different versions of HDF5 in the 1.8
+   series are usually compatible enough to work together.
 
 If everything is working you should be able to run the matlab unit tests
 by going to directory

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name = 'nwb',
@@ -8,5 +8,6 @@ setup(
     author_email='jteeters@berkeley.edu',
     description = 'Python API for Neurodata Without Borders (NWB) format',
     packages = ['nwb'],
+    install_requires = ['h5py']
     )
 


### PR DESCRIPTION
This both improves the documentation (for both Python & Matlab installs)
and adds a setuptools dependency on h5py so pip will pull it in
automatically.

Fixes issue #7.