### PR TITLE
Avoid `elementwise comparison failed` warning

### DIFF
--- a/nwb/find_links.py
+++ b/nwb/find_links.py
@@ -1384,6 +1384,8 @@ def values_match(x, y):
         # and x.shape == () and y.shape == ()
         and np.isnan(x) and np.isnan(y)):
         return True
+    if isinstance(y, str) and not isinstance(x, str):
+        return False
     try:
         eq = x==y
     except ValueError:


### PR DESCRIPTION
If you have an array as an attribute, you get the warning:
```
nwb/find_links.py:1388: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  eq = x==y
```
when it compares the array to the empty string. This happens for instance with the `starting_frame` attribute for an ImageSeries stored in external files.

Fixed by adding an explicit test for the case where we compare a non-string to a string. Note that `numpy.string_` is an instance of `str` so that comparison still goes to the `x==y` clause.