### PR TITLE
Make signature generation more flexible

### DIFF
--- a/nwb/h5diffsig.py
+++ b/nwb/h5diffsig.py
@@ -1307,36 +1307,36 @@ def diff_files(file1, file2):
 # used for profiling
 # import cProfile
 
-    
-if len(sys.argv) not in (2, 3, 4):
-    display_doc()
-    sys.exit(1)
-file1 = sys.argv[1]
-opts = sys.argv[-1].lstrip("-") if sys.argv[-1].startswith('-') and len(sys.argv[-1]) > 2 else None
-if len(sys.argv) == 4 and opts is None:
-    print("Third input parameter should be <opts>, but value found does not start with '-': %s" % sys.argv[3])
-    display_doc()
-    sys.exit(1)
-file2 = sys.argv[2] if (len(sys.argv) == 3 and opts is None) or len(sys.argv) > 3 else None
-if opts is not None:
-    given_opts = set(list(opts))
-    possible_options = set(['N', 'a'])
-    found_options = possible_options.intersection(given_opts)
-    unknown_options = list(given_opts - found_options)
-    if len(unknown_options) > 0:
-        print ("Unknown option(s) specified: %s.  Should include only: %s" % (unknown_options,
-        possible_options))
+if __name__ == '__main__':
+    if len(sys.argv) not in (2, 3, 4):
         display_doc()
         sys.exit(1)
-else:
-    found_options = []
-filter_nwb = ("N" in found_options)
-alpha_sort = ("a" in found_options)
-# set to True if this file is being compared to itself
-single_file = file2 is None
-if single_file: 
-    # compare file to itself to get information about links and sizes
-    diff_files(file1, file1)
-    # cProfile.run('diff_files("%s", "%s")' % (sys.argv[1], sys.argv[1]))
-else:
-    diff_files(file1, file2)
+    file1 = sys.argv[1]
+    opts = sys.argv[-1].lstrip("-") if sys.argv[-1].startswith('-') and len(sys.argv[-1]) > 2 else None
+    if len(sys.argv) == 4 and opts is None:
+        print("Third input parameter should be <opts>, but value found does not start with '-': %s" % sys.argv[3])
+        display_doc()
+        sys.exit(1)
+    file2 = sys.argv[2] if (len(sys.argv) == 3 and opts is None) or len(sys.argv) > 3 else None
+    if opts is not None:
+        given_opts = set(list(opts))
+        possible_options = set(['N', 'a'])
+        found_options = possible_options.intersection(given_opts)
+        unknown_options = list(given_opts - found_options)
+        if len(unknown_options) > 0:
+            print ("Unknown option(s) specified: %s.  Should include only: %s" % (unknown_options,
+            possible_options))
+            display_doc()
+            sys.exit(1)
+    else:
+        found_options = []
+    filter_nwb = ("N" in found_options)
+    alpha_sort = ("a" in found_options)
+    # set to True if this file is being compared to itself
+    single_file = file2 is None
+    if single_file:
+        # compare file to itself to get information about links and sizes
+        diff_files(file1, file1)
+        # cProfile.run('diff_files("%s", "%s")' % (sys.argv[1], sys.argv[1]))
+    else:
+        diff_files(file1, file2)

--- a/nwb/value_summary.py
+++ b/nwb/value_summary.py
@@ -253,7 +253,7 @@ def get_prefix(val, fileObj, num_chars):
         if isinstance(val, bytes) and version_info[0] > 2:
             try:
                 prefix = prefix.decode('utf-8')
-            except UnicodeDecodeError as e:
+            except UnicodeDecodeError:
                 # value is a binary string.
                 hash = hashval(val)
                 bmsg = "<<binary, hash=%s>>" % hash
@@ -283,7 +283,7 @@ def get_prefix(val, fileObj, num_chars):
         return prefix
     vs_msg = "Unknown type in value_summary.get_prefix, val=%s, type=%s" % (val, type(val))
     # vs_msg_type = "warning"
-    # import pdb; pdb.set_trace()  
+    # import pdb; pdb.set_trace()
     raise SystemError(vs_msg)
     return str(val)
 

--- a/nwb/value_summary.py
+++ b/nwb/value_summary.py
@@ -269,14 +269,14 @@ def get_prefix(val, fileObj, num_chars):
             hash = hash_str(val)
             prefix = "<<binary, hash=%s>>" % hash
             return prefix
-    elif isinstance(val, (float, np.float_, np.float32)):
+    elif isinstance(val, (float, np.floating)):
         val = float(val)
         if val.is_integer():
             prefix = str(int(val))
         else:
             prefix = "%-.4g" % val
         return prefix
-    elif isinstance(val, (int, np.int_, np.int8, np.int16, np.int32, np.uint8, np.uint16, np.uint32)):
+    elif isinstance(val, (int, np.integer)):
         return str(val)
     elif isinstance(val, h5py.h5r.RegionReference):
         prefix = summarize_region_reference(val, fileObj)


### PR DESCRIPTION
I had some float16 data in an NWB file, which caused creating a signature to throw. I don't think the `get_prefix` method needs to be specific to only a few integer or floating point data types.