### PR TITLE
NWB Utils/current_time(): Use correct time zone with timezone specifier

### DIFF
--- a/nwb/nwb_utils.py
+++ b/nwb/nwb_utils.py
@@ -14,8 +14,8 @@ def load_file(filename):
     return content
     
 def current_time():
-    """ Return current datetime in iso format"""
-    cur_time = datetime.datetime.now().isoformat()
+    """ Return current datetime in iso format with timezone UTC"""
+    cur_time = datetime.datetime.utcnow().isoformat() + "Z"
     return cur_time
 
 def create_identifier(base_string):


### PR DESCRIPTION
The routine current_time() is used, among other things, to populate the
/file_create_date dataset. This dataset should contain according to the
NWB specification in version 1.06 from April 8 2017:

"Date + time, Use ISO format (eg, ISO 8601) or a format that is
easy to read and unambiguous."

This goal is currently not reached as the timezone is the local time zone of the
computer running the software and the timezone is not mentioned.

To disambiguate this we now use the UTC timezone and also encode the UTC
timezone via the standardised "Z" prefix.

So instead of `2017-05-22T23:20:18.658000` we now have `2017-05-22T21:20:18.658000Z`.

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>